### PR TITLE
fix(ux): centralize loading flow with GameReadyGate component

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,6 +8,7 @@ import { GameProvider } from "@/context/GameContext";
 import { PuzzleHistoryProvider } from "@/context/PuzzleHistoryContext";
 import { WordDataProvider } from "@/context/WordDataContext";
 import { DrawerNavigationWrapper } from "@/components/DrawerNavigationWrapper";
+import { GameReadyGate } from "@/components/GameReadyGate";
 import { colors } from "@/constants/styles";
 
 SplashScreen.preventAutoHideAsync();
@@ -66,7 +67,9 @@ function RootLayoutContent() {
           >
             <WordDataProvider>
               <GameProvider>
-                <DrawerNavigationWrapper />
+                <GameReadyGate>
+                  <DrawerNavigationWrapper />
+                </GameReadyGate>
               </GameProvider>
             </WordDataProvider>
           </Suspense>

--- a/components/Game.tsx
+++ b/components/Game.tsx
@@ -13,7 +13,7 @@ import { useKeyboardListener } from "@/hooks/useKeyboardListener";
 import { useAccessibilityKeyboard } from "@/hooks/useAccessibilityKeyboard";
 
 export const Game = () => {
-  const { category, answer, isLoading } = useContext(GameContext);
+  const { category, answer } = useContext(GameContext);
 
   const [hintModalVisible, setHintModalVisible] = useState(false);
 
@@ -45,12 +45,6 @@ export const Game = () => {
       console.info({ answer, category });
     }
   }, [answer, category]);
-
-  // Prevent rendering during initial load to avoid layout shifts
-  // This ensures both GuessGrid and Keyboard render together
-  if (isLoading) {
-    return <View style={containerStyle} />;
-  }
 
   return (
     <View style={containerStyle}>

--- a/components/GameReadyGate.tsx
+++ b/components/GameReadyGate.tsx
@@ -1,0 +1,26 @@
+import { useContext } from "react";
+import { View, ActivityIndicator, StyleSheet } from "react-native";
+import { GameContext } from "@/context/GameContext";
+import { colors } from "@/constants/styles";
+
+export const GameReadyGate = ({ children }: { children: React.ReactNode }) => {
+  const { isLoading } = useContext(GameContext);
+
+  if (isLoading) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={colors.neutral.white} />
+      </View>
+    );
+  }
+
+  return <>{children}</>;
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    backgroundColor: colors.neutral.background,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `GameReadyGate` component that keeps loading spinner visible until `GameContext` finishes loading
- Wrap `DrawerNavigationWrapper` with `GameReadyGate` in root layout
- Remove redundant loading check from `Game` component

## Problem
The loading spinner (Suspense fallback) was disappearing when `WordDataProvider` resolved, but `GameContext` was still loading (puzzle, letter tracking, rehydration). This left users with a blank page for 2-4 seconds.

## Solution
Centralize the loading check at the layout level with a new `GameReadyGate` component that shows `ActivityIndicator` while `GameContext.isLoading` is true.

## Test plan
- [x] Run `npx expo start --web`
- [x] Clear browser storage/cache to simulate fresh daily visit
- [x] Verify loading spinner stays visible until game grid appears
- [x] No blank page appears between spinner and game

🤖 Generated with [Claude Code](https://claude.com/claude-code)