### PR TITLE
feat: apply Figma design language to WordCard, GameBanner, and tiles

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -438,6 +438,7 @@ The build and timing values in these instructions have been validated and measur
 For detailed information on specific features, see the `docs/` folder:
 
 - [DEVELOPMENT-GUIDE.md](../docs/DEVELOPMENT-GUIDE.md) - Quick start and common commands
+- [STYLING-GUIDE.md](../docs/STYLING-GUIDE.md) - Design system, constants, SubtleGradient
 - [WORD-MANAGEMENT-GUIDE.md](../docs/WORD-MANAGEMENT-GUIDE.md) - Complete word workflow
 - [WORD-MANAGEMENT-QUICK-REFERENCE.md](../docs/WORD-MANAGEMENT-QUICK-REFERENCE.md) - Quick command reference
 - [DAILY-PUZZLES.md](../docs/DAILY-PUZZLES.md) - Daily puzzle scheduling system

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "PSION",
     "RAIMI",
     "RENJI",
+    "rgba",
     "SAIYA",
     "Saiyan",
     "Sanji",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,18 @@ pnpm run words:validate
 
 ## File Locations
 
-| Purpose                     | Location          |
-| --------------------------- | ----------------- |
-| Word data (source of truth) | `data/words.json` |
-| App screens                 | `app/`            |
-| Components                  | `components/`     |
-| Backend API                 | `functions/src/`  |
-| Documentation               | `docs/`           |
+| Purpose                     | Location                   |
+| --------------------------- | -------------------------- |
+| Word data (source of truth) | `data/words.json`          |
+| Design tokens (colors, spacing, etc.) | `constants/styles.ts` |
+| App screens                 | `app/`                     |
+| Components                  | `components/`              |
+| Base components (Card, SubtleGradient) | `components/base/` |
+| Backend API                 | `functions/src/`           |
+| Documentation               | `docs/`                    |
+
+## Design System
+
+- **Dark gradient cards**: WordCard, GameBanner use `SubtleGradient` + `colors.wordCard`
+- **Constants**: All styling in `constants/styles.ts`; use constants, avoid magic numbers
+- **Details**: See [docs/STYLING-GUIDE.md](docs/STYLING-GUIDE.md)

--- a/components/AnswerRevealText.tsx
+++ b/components/AnswerRevealText.tsx
@@ -1,6 +1,5 @@
 import { Text, StyleSheet } from "react-native";
 import { colors, fontFamily, fontSize, lineHeight } from "@/constants/styles";
-import { opacity } from "@/constants/opacity";
 
 type AnswerRevealTextProps = {
   answer: string;
@@ -17,11 +16,12 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.bitter.bold,
     fontSize: fontSize.title.base,
     lineHeight: lineHeight.title.base,
+    color: colors.neutral.white,
   },
   subText: {
-    color: colors.neutral.black,
+    color: colors.wordCard.textSecondary,
     fontSize: fontSize.body.base,
-    fontFamily: fontFamily.openSans.medium,
-    opacity: opacity.subtle,
+    fontFamily: fontFamily.bitter.medium,
+    lineHeight: lineHeight.body.base,
   },
 });

--- a/components/BannerMessage.tsx
+++ b/components/BannerMessage.tsx
@@ -21,7 +21,7 @@ export const BannerMessage = ({
 
 const styles = StyleSheet.create({
   bannerText: {
-    color: colors.neutral.black,
+    color: colors.neutral.white,
     fontSize: fontSize.title.base,
     lineHeight: lineHeight.title.base,
     fontFamily: fontFamily.bitter.bold,

--- a/components/CollectedWordText.tsx
+++ b/components/CollectedWordText.tsx
@@ -1,6 +1,5 @@
 import { Text, StyleSheet } from "react-native";
 import { colors, fontFamily, fontSize, lineHeight } from "@/constants/styles";
-import { opacity } from "@/constants/opacity";
 
 type CollectedWordTextProps = {
   answer: string;
@@ -22,11 +21,12 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.bitter.bold,
     fontSize: fontSize.title.base,
     lineHeight: lineHeight.title.base,
+    color: colors.neutral.white,
   },
   subText: {
-    color: colors.neutral.black,
+    color: colors.wordCard.textSecondary,
     fontSize: fontSize.body.base,
-    fontFamily: fontFamily.openSans.medium,
-    opacity: opacity.subtle,
+    fontFamily: fontFamily.bitter.medium,
+    lineHeight: lineHeight.body.base,
   },
 });

--- a/components/GameBanner.tsx
+++ b/components/GameBanner.tsx
@@ -1,6 +1,12 @@
-import { StyleSheet } from "react-native";
-import { borderRadius, colors, spacing } from "@/constants/styles";
-// Note: Width should match the container (Game content). We use width: "100%".
+import { StyleSheet, View, Platform } from "react-native";
+import {
+  borderWidth,
+  borderRadius,
+  colors,
+  shadow,
+  spacing,
+} from "@/constants/styles";
+import { SubtleGradient } from "./base/SubtleGradient";
 import { Card } from "./base/Card";
 import { WordEntry } from "@/types/word";
 import { BannerMessage } from "./BannerMessage";
@@ -26,12 +32,36 @@ export const GameBanner = ({
 }: GameBannerProps) => {
   if (gameStatus === "running") return null;
 
-  const backgroundColor =
+  const accentColor =
     gameStatus === "won" ? colors.semantic.success : colors.semantic.warning;
 
   return (
-    <Card containerStyle={[styles.outer, { borderColor: backgroundColor }]}>
-      <Card containerStyle={[styles.inner, { backgroundColor }]}>
+    <Card
+      containerStyle={[
+        styles.container,
+        {
+          borderColor: accentColor,
+          backgroundColor: "transparent",
+          overflow: "hidden",
+          ...Platform.select({
+            ios: {
+              shadowColor: shadow.wordCard.color,
+              shadowOffset: {
+                width: shadow.wordCard.offsetX,
+                height: shadow.wordCard.offsetY,
+              },
+              shadowOpacity: shadow.wordCard.opacity,
+              shadowRadius: shadow.wordCard.radius,
+            },
+            android: { elevation: shadow.wordCard.elevation },
+          }),
+        },
+      ]}
+    >
+      <SubtleGradient
+        colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
+      />
+      <View style={styles.content}>
         <BannerMessage gameStatus={gameStatus} numGuesses={numGuesses} />
 
         {gameStatus === "won" && answer && (
@@ -47,19 +77,19 @@ export const GameBanner = ({
         {gameStatus === "lost" && answerEntry && (
           <WikipediaLink answerEntry={answerEntry} />
         )}
-      </Card>
+      </View>
     </Card>
   );
 };
 
 const styles = StyleSheet.create({
-  outer: {
-    borderWidth: 2,
+  container: {
+    borderWidth: borderWidth.wordCard,
+    borderRadius: borderRadius.card,
     width: "100%",
   },
-  inner: {
-    padding: spacing.sm,
-    borderRadius: borderRadius.sm,
+  content: {
+    padding: spacing.lg,
     gap: spacing.sm,
   },
 });

--- a/components/GameBanner.tsx
+++ b/components/GameBanner.tsx
@@ -1,11 +1,11 @@
-import { StyleSheet, View, Platform } from "react-native";
+import { StyleSheet, View } from "react-native";
 import {
   borderWidth,
   borderRadius,
   colors,
-  shadow,
   spacing,
 } from "@/constants/styles";
+import { getCardOverlayStyle, cardShadowStyle } from "@/utils/cardStyles";
 import { SubtleGradient } from "./base/SubtleGradient";
 import { Card } from "./base/Card";
 import { WordEntry } from "@/types/word";
@@ -36,49 +36,32 @@ export const GameBanner = ({
     gameStatus === "won" ? colors.semantic.success : colors.semantic.warning;
 
   return (
-    <Card
-      containerStyle={[
-        styles.container,
-        {
-          borderColor: accentColor,
-          backgroundColor: "transparent",
-          overflow: "hidden",
-          ...Platform.select({
-            ios: {
-              shadowColor: shadow.wordCard.color,
-              shadowOffset: {
-                width: shadow.wordCard.offsetX,
-                height: shadow.wordCard.offsetY,
-              },
-              shadowOpacity: shadow.wordCard.opacity,
-              shadowRadius: shadow.wordCard.radius,
-            },
-            android: { elevation: shadow.wordCard.elevation },
-          }),
-        },
-      ]}
-    >
-      <SubtleGradient
-        colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
-      />
-      <View style={styles.content}>
-        <BannerMessage gameStatus={gameStatus} numGuesses={numGuesses} />
+    <View style={cardShadowStyle}>
+      <Card
+        containerStyle={[styles.container, getCardOverlayStyle(accentColor)]}
+      >
+        <SubtleGradient
+          colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
+        />
+        <View style={styles.content}>
+          <BannerMessage gameStatus={gameStatus} numGuesses={numGuesses} />
 
-        {gameStatus === "won" && answer && (
-          <CollectedWordText answer={answer} edition={edition} />
-        )}
+          {gameStatus === "won" && answer && (
+            <CollectedWordText answer={answer} edition={edition} />
+          )}
 
-        {gameStatus === "won" && <SeeWordsLink />}
+          {gameStatus === "won" && <SeeWordsLink />}
 
-        {gameStatus === "lost" && answer && (
-          <AnswerRevealText answer={answer} />
-        )}
+          {gameStatus === "lost" && answer && (
+            <AnswerRevealText answer={answer} />
+          )}
 
-        {gameStatus === "lost" && answerEntry && (
-          <WikipediaLink answerEntry={answerEntry} />
-        )}
-      </View>
-    </Card>
+          {gameStatus === "lost" && answerEntry && (
+            <WikipediaLink answerEntry={answerEntry} />
+          )}
+        </View>
+      </Card>
+    </View>
   );
 };
 

--- a/components/LetterBox.tsx
+++ b/components/LetterBox.tsx
@@ -6,6 +6,7 @@ import {
   ViewStyle,
   Pressable,
 } from "react-native";
+import { SubtleGradient } from "./base/SubtleGradient";
 import {
   borderRadius,
   colors,
@@ -38,22 +39,38 @@ export const LetterBox = ({
 }: LetterBoxProps) => {
   const cellStyles: StyleProp<ViewStyle> = [styles.container];
 
-  if (!isCurrentGuess && letter) {
-    if (isCorrect) {
-      cellStyles.push({ backgroundColor: colors.semantic.success });
-    } else if (isPresent) {
-      cellStyles.push(styles.present);
-    } else {
-      cellStyles.push(styles.absent);
-    }
+  if (invalidWord) {
+    cellStyles.push(styles.invalidBorder);
   }
 
-  if (invalidWord) {
-    cellStyles.push(styles.invalid);
-  }
+  const feedbackBackground =
+    invalidWord
+      ? colors.neutral.darkGray
+      : !isCurrentGuess && letter
+        ? isCorrect
+          ? colors.semantic.success
+          : isPresent
+            ? colors.tiles.wrongPlace
+            : colors.neutral.black
+        : null;
 
   const letterBox = (
     <View style={cellStyles}>
+      {feedbackBackground ? (
+        <View
+          style={[
+            StyleSheet.absoluteFill,
+            { backgroundColor: feedbackBackground },
+          ]}
+        />
+      ) : (
+        <SubtleGradient
+          colors={[
+            colors.tiles.defaultGradientStart,
+            colors.tiles.defaultGradientEnd,
+          ]}
+        />
+      )}
       <Text style={styles.letter}>{letter}</Text>
       {showHint && (
         <>
@@ -93,10 +110,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.neutral.lightGray,
     justifyContent: "center",
-    backgroundColor: colors.tiles.default,
     alignItems: "center",
     borderRadius: borderRadius.md,
     position: "relative",
+    overflow: "hidden",
   },
   letter: {
     fontFamily: fontFamily.bitter.bold,
@@ -104,15 +121,8 @@ const styles = StyleSheet.create({
     lineHeight: lineHeight.title.large,
     color: colors.neutral.white,
   },
-  present: {
-    backgroundColor: colors.tiles.wrongPlace,
-  },
-  absent: {
-    backgroundColor: colors.neutral.black,
-  },
-  invalid: {
+  invalidBorder: {
     borderColor: colors.neutral.white,
-    backgroundColor: colors.neutral.darkGray,
   },
   previewLetter: {
     textAlign: "center",

--- a/components/LetterBox.tsx
+++ b/components/LetterBox.tsx
@@ -55,31 +55,31 @@ export const LetterBox = ({
         : null;
 
   const letterBox = (
-    <View style={cellStyles}>
-      {feedbackBackground ? (
-        <View
-          style={[
-            StyleSheet.absoluteFill,
-            { backgroundColor: feedbackBackground },
-          ]}
-        />
-      ) : (
-        <SubtleGradient
-          colors={[
-            colors.tiles.defaultGradientStart,
-            colors.tiles.defaultGradientEnd,
-          ]}
-        />
-      )}
-      <Text style={styles.letter}>{letter}</Text>
-      {showHint && (
-        <>
-          <HintOutline />
+    <View style={styles.outerContainer}>
+      {showHint && <HintOutline />}
+      <View style={cellStyles}>
+        {feedbackBackground ? (
+          <View
+            style={[
+              StyleSheet.absoluteFill,
+              { backgroundColor: feedbackBackground },
+            ]}
+          />
+        ) : (
+          <SubtleGradient
+            colors={[
+              colors.tiles.defaultGradientStart,
+              colors.tiles.defaultGradientEnd,
+            ]}
+          />
+        )}
+        <Text style={styles.letter}>{letter}</Text>
+        {showHint && (
           <View style={styles.previewLetterWrapper}>
             <Text style={styles.previewLetter}>{hintLetter.toUpperCase()}</Text>
           </View>
-        </>
-      )}
+        )}
+      </View>
     </View>
   );
 
@@ -104,9 +104,14 @@ const styles = StyleSheet.create({
   pressableContainer: {
     flexGrow: 1,
   },
-  container: {
+  outerContainer: {
     flexGrow: 1,
     aspectRatio: 1,
+    position: "relative",
+  },
+  container: {
+    width: "100%",
+    height: "100%",
     borderWidth: 1,
     borderColor: colors.neutral.lightGray,
     justifyContent: "center",

--- a/components/SeeWordsLink.tsx
+++ b/components/SeeWordsLink.tsx
@@ -1,7 +1,6 @@
 import { Text, Pressable, StyleSheet } from "react-native";
 import { Link } from "expo-router";
 import { colors, fontFamily, fontSize, lineHeight } from "@/constants/styles";
-import { opacity } from "@/constants/opacity";
 import { SvgIcon } from "./base/SvgIcon";
 import { iconSizes } from "@/constants/icons";
 
@@ -12,7 +11,7 @@ export const SeeWordsLink = () => (
         See your <Text style={styles.nerdWordText}>NerdWord</Text>
       </Text>
       <SvgIcon
-        color={colors.neutral.black}
+        color={colors.wordCard.textMuted}
         name="chevron-right"
         size={iconSizes.small}
       />
@@ -29,12 +28,12 @@ const styles = StyleSheet.create({
     fontFamily: fontFamily.bitter.bold,
     fontSize: fontSize.body.base,
     lineHeight: lineHeight.body.base,
+    color: colors.neutral.white,
   },
   linkText: {
-    color: colors.neutral.black,
+    color: colors.wordCard.textMuted,
     fontSize: fontSize.body.base,
-    fontFamily: fontFamily.openSans.medium,
+    fontFamily: fontFamily.bitter.medium,
     lineHeight: lineHeight.body.base,
-    opacity: opacity.subtle,
   },
 });

--- a/components/WikipediaLink.tsx
+++ b/components/WikipediaLink.tsx
@@ -1,6 +1,5 @@
 import { Text, Pressable, Linking, StyleSheet } from "react-native";
 import { colors, fontFamily, fontSize, lineHeight } from "@/constants/styles";
-import { opacity } from "@/constants/opacity";
 import { WordEntry } from "@/types/word";
 import { SvgIcon } from "./base/SvgIcon";
 import { iconSizes } from "@/constants/icons";
@@ -28,7 +27,7 @@ export const WikipediaLink = ({ answerEntry }: WikipediaLinkProps) => {
     <Pressable onPress={handleWikipediaPress} style={styles.container}>
       <Text style={styles.linkText}>Learn more on Wikipedia</Text>
       <SvgIcon
-        color={colors.neutral.black}
+        color={colors.wordCard.textMuted}
         name="chevron-right"
         size={iconSizes.small}
       />
@@ -42,10 +41,9 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   linkText: {
-    color: colors.neutral.black,
+    color: colors.wordCard.textMuted,
     fontSize: fontSize.body.base,
     lineHeight: lineHeight.body.base,
-    fontFamily: fontFamily.openSans.medium,
-    opacity: opacity.subtle,
+    fontFamily: fontFamily.bitter.medium,
   },
 });

--- a/components/WordCard.tsx
+++ b/components/WordCard.tsx
@@ -1,26 +1,35 @@
-import { StyleSheet, Text, View, Pressable, Linking } from "react-native";
-import { Card } from "./base/Card";
-import { SvgIcon } from "./base/SvgIcon";
 import {
+  StyleSheet,
+  Text,
+  View,
+  Pressable,
+  Linking,
+  Platform,
+} from "react-native";
+import { SubtleGradient } from "./base/SubtleGradient";
+import { Card } from "./base/Card";
+import {
+  colors,
+  borderWidth,
   borderRadius,
   fontFamily,
   fontSize,
   lineHeight,
+  shadow,
   spacing,
 } from "@/constants/styles";
-import { iconSizes } from "@/constants/icons";
 import {
   WORD_CARD_MAX_WIDTH,
   WORD_CARD_MIN_WIDTH,
 } from "@/constants/dimensions";
 import {
   getCategoryColor,
-  getCategoryTextColor,
   getSummaryForWord,
   convertCategory,
 } from "@/utils/game";
 import { CollectedWord } from "@/hooks/useCollectedWords";
 import { getShortDateString } from "@/utils/time";
+import { hexToRgba } from "@/utils/color";
 
 type WordCardProps = {
   collectedWord: CollectedWord;
@@ -31,10 +40,7 @@ export const WordCard = ({ collectedWord }: WordCardProps) => {
   const answer = wordEntry.id;
 
   const summary = getSummaryForWord(wordEntry);
-  const tileBackgroundColor = getCategoryColor(category);
-  const textColor = getCategoryTextColor(category);
-
-  // Format the category display name
+  const accentColor = getCategoryColor(category);
   const formattedCategory = convertCategory(category);
 
   const handleWikipediaPress = () => {
@@ -43,109 +49,144 @@ export const WordCard = ({ collectedWord }: WordCardProps) => {
     }
   };
 
-  // Format date as MM/DD/YY using timezone-aware utility
   const formattedDate = getShortDateString(completedDate);
 
   return (
     <Card
-      containerStyle={[styles.container, { borderColor: tileBackgroundColor }]}
+      containerStyle={[styles.container, getContainerOverlayStyle(accentColor)]}
     >
-      <Card
-        containerStyle={[
-          styles.content,
-          { backgroundColor: tileBackgroundColor },
-        ]}
-      >
+      <SubtleGradient
+        colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
+      />
+      <View style={styles.content}>
         <View style={styles.answerEditionRow}>
-          <Text style={[styles.answerText, { color: textColor }]}>
-            {answer}
-          </Text>
-          <View>
-            <Text style={[styles.editionText, { color: textColor }]}>
-              #{editionNumber}
-            </Text>
-            <Text style={[styles.dateText, { color: textColor }]}>
-              {formattedDate}
+          <Text style={styles.answerText}>{answer}</Text>
+          <View style={styles.editionDateBlock}>
+            <Text style={styles.editionText}>#{editionNumber}</Text>
+            <Text style={styles.dateText}>{formattedDate}</Text>
+          </View>
+        </View>
+
+        <Text style={styles.summaryText}>{summary}</Text>
+
+        <View style={styles.wikipediaSection}>
+          <Pressable onPress={handleWikipediaPress}>
+            <Text style={styles.linkText}>Wikipedia →</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.badgeContainer}>
+          <View
+            style={[
+              styles.categoryBadge,
+              {
+                backgroundColor: hexToRgba(
+                  accentColor,
+                  colors.wordCard.badgeBackgroundOpacity
+                ),
+                borderColor: hexToRgba(
+                  accentColor,
+                  colors.wordCard.badgeBorderOpacity
+                ),
+              },
+            ]}
+          >
+            <Text style={[styles.categoryText, { color: accentColor }]}>
+              {formattedCategory}
             </Text>
           </View>
         </View>
-        <Text style={[styles.summaryText, { color: textColor }]}>
-          {summary}
-        </Text>
-        <Pressable onPress={handleWikipediaPress}>
-          <View style={styles.linkContainer}>
-            <Text style={[styles.linkText, { color: textColor }]}>
-              Wikipedia
-            </Text>
-            <SvgIcon
-              name="chevron-right"
-              size={iconSizes.small}
-              color={textColor}
-            />
-          </View>
-        </Pressable>
-        <Text style={[styles.categoryText, { color: textColor }]}>
-          {formattedCategory}
-        </Text>
-      </Card>
+      </View>
     </Card>
   );
 };
+
+const getContainerOverlayStyle = (accentColor: string) => ({
+  borderColor: accentColor,
+  backgroundColor: "transparent" as const,
+  overflow: "hidden" as const,
+  ...Platform.select({
+    ios: {
+      shadowColor: shadow.wordCard.color,
+      shadowOffset: {
+        width: shadow.wordCard.offsetX,
+        height: shadow.wordCard.offsetY,
+      },
+      shadowOpacity: shadow.wordCard.opacity,
+      shadowRadius: shadow.wordCard.radius,
+    },
+    android: { elevation: shadow.wordCard.elevation },
+  }),
+});
 
 const styles = StyleSheet.create({
   container: {
     minWidth: WORD_CARD_MIN_WIDTH,
     maxWidth: WORD_CARD_MAX_WIDTH,
     width: "100%",
-    borderWidth: 2,
+    borderWidth: borderWidth.wordCard,
+    borderRadius: borderRadius.card,
   },
   content: {
-    flex: 1,
-    gap: spacing.md,
-    borderRadius: borderRadius.sm,
-    padding: spacing.sm,
+    padding: spacing.lg,
+    gap: spacing.sm,
   },
   answerEditionRow: {
     flexDirection: "row",
     justifyContent: "space-between",
+    alignItems: "flex-start",
+    marginBottom: spacing.md,
   },
   answerText: {
     fontSize: fontSize.title.xLarge,
     lineHeight: lineHeight.title.xLarge,
     fontFamily: fontFamily.bitter.bold,
+    color: colors.neutral.white,
+  },
+  editionDateBlock: {
+    alignItems: "flex-end",
   },
   editionText: {
-    fontSize: fontSize.title.xLarge,
-    lineHeight: lineHeight.title.xLarge,
+    fontSize: fontSize.title.large,
+    lineHeight: lineHeight.title.large,
     fontFamily: fontFamily.bitter.bold,
+    color: colors.neutral.white,
   },
   dateText: {
-    fontSize: fontSize.body.base,
-    lineHeight: lineHeight.body.base,
-    fontFamily: fontFamily.bitter.regular,
-  },
-  hintText: {
-    fontSize: fontSize.title.medium,
-    lineHeight: lineHeight.title.medium,
-    fontFamily: fontFamily.bitter.italic,
+    fontSize: fontSize.body.small,
+    lineHeight: lineHeight.body.small,
+    fontFamily: fontFamily.bitter.medium,
+    color: colors.wordCard.textSecondary,
   },
   summaryText: {
     fontSize: fontSize.body.base,
     lineHeight: lineHeight.body.base,
-    fontFamily: fontFamily.bitter.regular,
+    fontFamily: fontFamily.bitter.medium,
+    color: colors.wordCard.textPrimary,
+    marginBottom: spacing.md,
+  },
+  wikipediaSection: {
+    borderTopWidth: borderWidth.divider,
+    borderTopColor: colors.wordCard.divider,
+    paddingTop: spacing.smMd,
   },
   linkText: {
-    fontSize: fontSize.body.base,
-    lineHeight: lineHeight.body.base,
-    fontFamily: fontFamily.bitter.regular,
+    fontSize: fontSize.body.small,
+    fontFamily: fontFamily.bitter.medium,
+    color: colors.wordCard.textMuted,
   },
-  linkContainer: {
-    flexDirection: "row",
-    alignItems: "center",
+  badgeContainer: {
+    marginTop: spacing.smMd,
+  },
+  categoryBadge: {
+    alignSelf: "flex-start",
+    paddingHorizontal: spacing.smMd,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.pill,
+    borderWidth: borderWidth.badge,
   },
   categoryText: {
-    fontSize: fontSize.title.base,
-    lineHeight: lineHeight.title.base,
+    fontSize: fontSize.body.small,
     fontFamily: fontFamily.bitter.bold,
   },
 });

--- a/components/WordCard.tsx
+++ b/components/WordCard.tsx
@@ -1,11 +1,4 @@
-import {
-  StyleSheet,
-  Text,
-  View,
-  Pressable,
-  Linking,
-  Platform,
-} from "react-native";
+import { StyleSheet, Text, View, Pressable, Linking } from "react-native";
 import { SubtleGradient } from "./base/SubtleGradient";
 import { Card } from "./base/Card";
 import {
@@ -15,9 +8,12 @@ import {
   fontFamily,
   fontSize,
   lineHeight,
-  shadow,
   spacing,
 } from "@/constants/styles";
+import {
+  getCardOverlayStyle,
+  cardShadowStyle,
+} from "@/utils/cardStyles";
 import {
   WORD_CARD_MAX_WIDTH,
   WORD_CARD_MIN_WIDTH,
@@ -52,72 +48,56 @@ export const WordCard = ({ collectedWord }: WordCardProps) => {
   const formattedDate = getShortDateString(completedDate);
 
   return (
-    <Card
-      containerStyle={[styles.container, getContainerOverlayStyle(accentColor)]}
-    >
-      <SubtleGradient
-        colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
-      />
-      <View style={styles.content}>
-        <View style={styles.answerEditionRow}>
-          <Text style={styles.answerText}>{answer}</Text>
-          <View style={styles.editionDateBlock}>
-            <Text style={styles.editionText}>#{editionNumber}</Text>
-            <Text style={styles.dateText}>{formattedDate}</Text>
+    <View style={cardShadowStyle}>
+      <Card
+        containerStyle={[styles.container, getCardOverlayStyle(accentColor)]}
+      >
+        <SubtleGradient
+          colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]}
+        />
+        <View style={styles.content}>
+          <View style={styles.answerEditionRow}>
+            <Text style={styles.answerText}>{answer}</Text>
+            <View style={styles.editionDateBlock}>
+              <Text style={styles.editionText}>#{editionNumber}</Text>
+              <Text style={styles.dateText}>{formattedDate}</Text>
+            </View>
+          </View>
+
+          <Text style={styles.summaryText}>{summary}</Text>
+
+          <View style={styles.wikipediaSection}>
+            <Pressable onPress={handleWikipediaPress}>
+              <Text style={styles.linkText}>Wikipedia →</Text>
+            </Pressable>
+          </View>
+
+          <View style={styles.badgeContainer}>
+            <View
+              style={[
+                styles.categoryBadge,
+                {
+                  backgroundColor: hexToRgba(
+                    accentColor,
+                    colors.wordCard.badgeBackgroundOpacity
+                  ),
+                  borderColor: hexToRgba(
+                    accentColor,
+                    colors.wordCard.badgeBorderOpacity
+                  ),
+                },
+              ]}
+            >
+              <Text style={[styles.categoryText, { color: accentColor }]}>
+                {formattedCategory}
+              </Text>
+            </View>
           </View>
         </View>
-
-        <Text style={styles.summaryText}>{summary}</Text>
-
-        <View style={styles.wikipediaSection}>
-          <Pressable onPress={handleWikipediaPress}>
-            <Text style={styles.linkText}>Wikipedia →</Text>
-          </Pressable>
-        </View>
-
-        <View style={styles.badgeContainer}>
-          <View
-            style={[
-              styles.categoryBadge,
-              {
-                backgroundColor: hexToRgba(
-                  accentColor,
-                  colors.wordCard.badgeBackgroundOpacity
-                ),
-                borderColor: hexToRgba(
-                  accentColor,
-                  colors.wordCard.badgeBorderOpacity
-                ),
-              },
-            ]}
-          >
-            <Text style={[styles.categoryText, { color: accentColor }]}>
-              {formattedCategory}
-            </Text>
-          </View>
-        </View>
-      </View>
-    </Card>
+      </Card>
+    </View>
   );
 };
-
-const getContainerOverlayStyle = (accentColor: string) => ({
-  borderColor: accentColor,
-  backgroundColor: "transparent" as const,
-  overflow: "hidden" as const,
-  ...Platform.select({
-    ios: {
-      shadowColor: shadow.wordCard.color,
-      shadowOffset: {
-        width: shadow.wordCard.offsetX,
-        height: shadow.wordCard.offsetY,
-      },
-      shadowOpacity: shadow.wordCard.opacity,
-      shadowRadius: shadow.wordCard.radius,
-    },
-    android: { elevation: shadow.wordCard.elevation },
-  }),
-});
 
 const styles = StyleSheet.create({
   container: {

--- a/components/base/SubtleGradient.tsx
+++ b/components/base/SubtleGradient.tsx
@@ -1,0 +1,25 @@
+import { StyleSheet, ViewStyle } from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { colors } from "@/constants/styles";
+
+type SubtleGradientProps = {
+  /** Gradient colors from top-left to bottom-right */
+  colors: [string, string];
+  style?: ViewStyle;
+};
+
+/**
+ * A subtle top-left to bottom-right gradient fill.
+ * Used for WordCard, LetterBox tiles, and similar components.
+ */
+export const SubtleGradient = ({
+  colors: gradientColors,
+  style,
+}: SubtleGradientProps) => (
+  <LinearGradient
+    colors={gradientColors}
+    start={colors.gradient.startPoint}
+    end={colors.gradient.endPoint}
+    style={[StyleSheet.absoluteFill, style]}
+  />
+);

--- a/components/base/SubtleGradient.tsx
+++ b/components/base/SubtleGradient.tsx
@@ -1,11 +1,11 @@
-import { StyleSheet, ViewStyle } from "react-native";
+import { StyleSheet, StyleProp, ViewStyle } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import { colors } from "@/constants/styles";
+import { gradient } from "@/constants/styles";
 
 type SubtleGradientProps = {
   /** Gradient colors from top-left to bottom-right */
   colors: [string, string];
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
 };
 
 /**
@@ -18,8 +18,8 @@ export const SubtleGradient = ({
 }: SubtleGradientProps) => (
   <LinearGradient
     colors={gradientColors}
-    start={colors.gradient.startPoint}
-    end={colors.gradient.endPoint}
+    start={gradient.startPoint}
+    end={gradient.endPoint}
     style={[StyleSheet.absoluteFill, style]}
   />
 );

--- a/constants/styles.ts
+++ b/constants/styles.ts
@@ -17,10 +17,6 @@ const colors = {
     defaultGradientEnd: "#1a1e24",
     wrongPlace: "#DAA520",
   },
-  gradient: {
-    startPoint: { x: 0, y: 0 },
-    endPoint: { x: 1, y: 1 },
-  },
   neutral: {
     white: "#ffffff",
     background: "#1e212b",
@@ -126,6 +122,11 @@ const animation = {
   },
 } as const;
 
+const gradient = {
+  startPoint: { x: 0, y: 0 },
+  endPoint: { x: 1, y: 1 },
+} as const;
+
 const shadow = {
   wordCard: {
     color: colors.neutral.black,
@@ -146,5 +147,6 @@ export {
   borderWidth,
   borderRadius,
   animation,
+  gradient,
   shadow,
 };

--- a/constants/styles.ts
+++ b/constants/styles.ts
@@ -13,7 +13,13 @@ const colors = {
   tiles: {
     // TODO: Revisit this default color
     default: "#242730",
+    defaultGradientStart: "#2c3038",
+    defaultGradientEnd: "#1a1e24",
     wrongPlace: "#DAA520",
+  },
+  gradient: {
+    startPoint: { x: 0, y: 0 },
+    endPoint: { x: 1, y: 1 },
   },
   neutral: {
     white: "#ffffff",
@@ -21,6 +27,16 @@ const colors = {
     black: "#000000",
     lightGray: "#e9eaf2",
     darkGray: "#464d5f",
+  },
+  wordCard: {
+    gradientStart: "#242832",
+    gradientEnd: "#14161d",
+    badgeBackgroundOpacity: 0.2,
+    badgeBorderOpacity: 0.4,
+    textPrimary: "rgba(255,255,255,0.8)",
+    textSecondary: "rgba(255,255,255,0.6)",
+    textMuted: "rgba(255,255,255,0.5)",
+    divider: "rgba(255,255,255,0.1)",
   },
   semantic: {
     success: "#26be95",
@@ -72,24 +88,33 @@ const lineHeight = {
     large: 24,
     medium: 24,
     base: 24,
-    small: 18,
+    small: 20,
   },
 };
 
 const spacing = {
   xs: 4,
   sm: 8,
+  smMd: 12,
   md: 16,
   lg: 24,
   xl: 32,
   xxl: 48,
 } as const;
 
+const borderWidth = {
+  wordCard: 2,
+  badge: 1,
+  divider: 1,
+} as const;
+
 const borderRadius = {
   sm: 4,
   md: 8,
+  card: 12,
   lg: 16,
   xl: 24,
+  pill: 999,
   round: "50%",
 } as const;
 
@@ -101,12 +126,25 @@ const animation = {
   },
 } as const;
 
+const shadow = {
+  wordCard: {
+    color: colors.neutral.black,
+    offsetX: 0,
+    offsetY: 8,
+    opacity: 0.4,
+    radius: 24,
+    elevation: 8,
+  },
+} as const;
+
 export {
   colors,
   fontFamily,
   fontSize,
   lineHeight,
   spacing,
+  borderWidth,
   borderRadius,
   animation,
+  shadow,
 };

--- a/docs/STYLING-GUIDE.md
+++ b/docs/STYLING-GUIDE.md
@@ -1,0 +1,67 @@
+# Styling Guide
+
+Design system and styling patterns for NerdWord components.
+
+## Design Language
+
+Cards and tiles use a **dark gradient background** with **accent borders**, **subtle shadows**, and **light text hierarchy** for consistent depth and contrast.
+
+### Key Patterns
+
+- **Dark gradient fills**: Top-left (lighter) to bottom-right (darker)
+- **Accent borders**: Category or semantic color at 2px
+- **White text hierarchy**: 100% (primary), 80% (body), 60% (secondary), 50% (muted/links)
+- **Shadows**: 8px offset, 24px radius on cards
+
+## Constants Location
+
+All design tokens live in `constants/styles.ts`:
+
+| Token | Purpose |
+|-------|---------|
+| `colors.wordCard` | Dark card gradient, text hierarchy, badge opacity |
+| `colors.tiles` | Tile gradient for LetterBox |
+| `colors.gradient` | Shared gradient direction (top-left → bottom-right) |
+| `colors.categories` | Category accent colors |
+| `shadow.wordCard` | Card shadow (iOS + Android) |
+| `borderWidth`, `borderRadius` | Layout constants |
+
+## Shared Components
+
+### SubtleGradient
+
+`components/base/SubtleGradient.tsx` — Reusable gradient fill for dark card/tile backgrounds.
+
+```tsx
+<SubtleGradient colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]} />
+```
+
+Uses `colors.gradient.startPoint` and `colors.gradient.endPoint` (top-left to bottom-right).
+
+### Card
+
+`components/base/Card.tsx` — Base card wrapper. Use with `containerStyle` to override defaults (padding, background, border).
+
+## Components Using This Design
+
+| Component | Gradient | Accent | Notes |
+|-----------|----------|--------|-------|
+| WordCard | wordCard | Category color | Collected words list |
+| GameBanner | wordCard | Success (teal) / Warning (amber) | Win/loss banner |
+| LetterBox | tiles.defaultGradient* | — | Empty tile cells |
+
+## Utilities
+
+### hexToRgba
+
+`utils/color.ts` — Converts hex colors to rgba for opacity variants (e.g., badge backgrounds).
+
+```ts
+hexToRgba("#ff0200", 0.2) // "rgba(255,2,0,0.2)"
+```
+
+## Rules
+
+1. **Use constants** — Avoid hardcoded colors, spacing, or typography
+2. **Prefer SubtleGradient** — For new dark card/tile backgrounds
+3. **Text on dark backgrounds** — Use `colors.wordCard.textPrimary/Secondary/Muted` or `colors.neutral.white`

--- a/docs/STYLING-GUIDE.md
+++ b/docs/STYLING-GUIDE.md
@@ -21,7 +21,7 @@ All design tokens live in `constants/styles.ts`:
 |-------|---------|
 | `colors.wordCard` | Dark card gradient, text hierarchy, badge opacity |
 | `colors.tiles` | Tile gradient for LetterBox |
-| `colors.gradient` | Shared gradient direction (top-left → bottom-right) |
+| `gradient` | Shared gradient direction (top-left → bottom-right) |
 | `colors.categories` | Category accent colors |
 | `shadow.wordCard` | Card shadow (iOS + Android) |
 | `borderWidth`, `borderRadius` | Layout constants |
@@ -36,7 +36,7 @@ All design tokens live in `constants/styles.ts`:
 <SubtleGradient colors={[colors.wordCard.gradientStart, colors.wordCard.gradientEnd]} />
 ```
 
-Uses `colors.gradient.startPoint` and `colors.gradient.endPoint` (top-left to bottom-right).
+Uses `gradient.startPoint` and `gradient.endPoint` (top-level export, top-left to bottom-right).
 
 ### Card
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "expo-dev-client": "~5.2.4",
     "expo-device": "~7.1.4",
     "expo-font": "~13.3.2",
+    "expo-linear-gradient": "^15.0.8",
     "expo-linking": "~7.1.7",
     "expo-router": "~5.1.10",
     "expo-splash-screen": "~0.30.10",
@@ -88,7 +89,9 @@
   "private": true,
   "expo": {
     "install": {
-      "exclude": ["expo-doctor"]
+      "exclude": [
+        "expo-doctor"
+      ]
     },
     "doctor": {
       "reactNativeDirectoryCheck": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       expo-font:
         specifier: ~13.3.2
         version: 13.3.2(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react@19.0.0)
+      expo-linear-gradient:
+        specifier: ^15.0.8
+        version: 15.0.8(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       expo-linking:
         specifier: ~7.1.7
         version: 7.1.7(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -2542,6 +2545,13 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linear-gradient@15.0.8:
+    resolution: {integrity: sha512-V2d8Wjn0VzhPHO+rrSBtcl+Fo+jUUccdlmQ6OoL9/XQB7Qk3d9lYrqKDJyccwDxmQT10JdST3Tmf2K52NLc3kw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-linking@7.1.7:
     resolution: {integrity: sha512-ZJaH1RIch2G/M3hx2QJdlrKbYFUTOjVVW4g39hfxrE5bPX9xhZUYXqxqQtzMNl1ylAevw9JkgEfWbBWddbZ3UA==}
@@ -8108,6 +8118,12 @@ snapshots:
     dependencies:
       expo: 53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
       react: 19.0.0
+
+  expo-linear-gradient@15.0.8(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      expo: 53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
+      react: 19.0.0
+      react-native: 0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)
 
   expo-linking@7.1.7(expo@53.0.25(@babel/core@7.28.5)(@expo/metro-runtime@5.0.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.6(@babel/core@7.28.5)(@types/react@19.0.14)(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/utils/cardStyles.ts
+++ b/utils/cardStyles.ts
@@ -1,0 +1,21 @@
+import { Platform, ViewStyle } from "react-native";
+import { shadow } from "@/constants/styles";
+
+export const getCardOverlayStyle = (accentColor: string): ViewStyle => ({
+  borderColor: accentColor,
+  backgroundColor: "transparent",
+  overflow: "hidden",
+});
+
+export const cardShadowStyle: ViewStyle = Platform.select({
+  ios: {
+    shadowColor: shadow.wordCard.color,
+    shadowOffset: {
+      width: shadow.wordCard.offsetX,
+      height: shadow.wordCard.offsetY,
+    },
+    shadowOpacity: shadow.wordCard.opacity,
+    shadowRadius: shadow.wordCard.radius,
+  },
+  android: { elevation: shadow.wordCard.elevation },
+}) as ViewStyle;

--- a/utils/color.ts
+++ b/utils/color.ts
@@ -1,0 +1,11 @@
+/**
+ * Convert a hex color to rgba string
+ */
+export function hexToRgba(hex: string, alpha: number): string {
+  const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!result) return hex;
+  const r = parseInt(result[1], 16);
+  const g = parseInt(result[2], 16);
+  const b = parseInt(result[3], 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}

--- a/utils/game.ts
+++ b/utils/game.ts
@@ -117,33 +117,6 @@ export const getCategoryColor = (category: string): string => {
   }
 };
 
-export const getCategoryTextColor = (category: string) => {
-  switch (category) {
-    case "videoGames":
-      return colors.neutral.black;
-    case "science":
-      return colors.neutral.black;
-    case "fantasyAndSciFi":
-      return colors.neutral.black;
-    case "animeAndManga":
-      return colors.neutral.black;
-    case "tabletopAndBoardGames":
-      return colors.neutral.black;
-    case "techAndInternetCulture":
-      return colors.neutral.black;
-    case "superheroes":
-      return colors.neutral.white;
-    case "movies":
-      return colors.neutral.black;
-    case "literature":
-      return colors.neutral.white;
-    case "common":
-      return colors.neutral.white; // Dark gray background needs white text
-    default:
-      return colors.neutral.black;
-  }
-};
-
 /**
  * Initialize game with daily word (simplified version)
  *


### PR DESCRIPTION
## Summary

Applies the Figma design language to WordCard, GameBanner, and LetterBox tiles with a consistent dark gradient + accent border visual system.

- **Dark gradient cards**: WordCard and GameBanner use `SubtleGradient` (new `expo-linear-gradient` base component) with dark backgrounds, accent-colored borders, and platform shadows
- **Updated tile rendering**: LetterBox uses gradient backgrounds by default, overlaying solid colors for feedback states (correct/present/absent)
- **Design tokens**: New `colors.wordCard` palette, `gradient` coordinates, `shadow`, `borderWidth`, and `borderRadius` constants in `constants/styles.ts`
- **Typography refresh**: Standardized on Bitter font family with white text hierarchy (100%/80%/60%/50% opacity levels)
- **Shadow/overflow fix**: Separated shadow and `overflow: "hidden"` into distinct Views so iOS renders shadows correctly while still clipping gradients at rounded corners
- **HintOutline fix**: Split LetterBox into outer/inner containers so the pulsing hint animation extends beyond the tile without being clipped
- **Shared utilities**: `utils/cardStyles.ts` (card overlay + shadow helpers), `utils/color.ts` (`hexToRgba`), `components/base/SubtleGradient.tsx`
- **Cleanup**: Removed dead `getCategoryTextColor`, moved gradient coords out of `colors` to top-level `gradient` constant, fixed `SubtleGradient` style prop type to `StyleProp<ViewStyle>`
- **Docs**: Added `docs/STYLING-GUIDE.md` and updated CLAUDE.md with design system references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI/theming refactor plus a new `expo-linear-gradient` dependency; risk is mostly visual regressions (layout/contrast) rather than logic changes.
> 
> **Overview**
> Applies a new dark-gradient card/tile design language across `WordCard`, `GameBanner`, and `LetterBox`, including accent borders, platform shadows, and a standardized white text hierarchy.
> 
> Introduces shared styling primitives and tokens: `components/base/SubtleGradient` (via new `expo-linear-gradient` dependency), `utils/cardStyles` for border/shadow wrappers, `utils/color.hexToRgba` for badge opacities, and expanded design constants in `constants/styles.ts` (new `colors.wordCard`, gradients, shadows, border widths/radii, spacing tweaks). Also removes the unused `getCategoryTextColor` utility and adds `docs/STYLING-GUIDE.md` with updated internal instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04b842725d9c081d2f826591e75fa532052f42cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->